### PR TITLE
fixed file extention for FileNameExtensionFilter in installPluginMenu

### DIFF
--- a/VRL-Studio/src/eu/mihosoft/vrlstudio/main/Studio.java
+++ b/VRL-Studio/src/eu/mihosoft/vrlstudio/main/Studio.java
@@ -1761,7 +1761,7 @@ private void deleteAllVersionsMenuItemActionPerformed(java.awt.event.ActionEvent
 
         final JFileChooser fc = new VFileChooser(FileDialogManager.getDefaultDir());
 
-        fc.setFileFilter(new FileNameExtensionFilter("VRL-Plugins (*.jar)", ".jar"));
+        fc.setFileFilter(new FileNameExtensionFilter("VRL-Plugins (*.jar)", "jar"));
 
         fc.setMultiSelectionEnabled(true);
 


### PR DESCRIPTION
At the moment when you try to install a plugin, the jar files are not shown so you have to change file extention to *.* to select the jar files.